### PR TITLE
Update cached assets for service worker offline support

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,8 @@ const DATA_CACHE_NAME = 'police-events-data-v1.2';
 // Static assets to cache
 const STATIC_ASSETS = [
   '/',
-  '/police-events-map-professional.html',
+  '/index.html',
+  '/js/enhanced-popup.js',
   'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css',
   'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
   'https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css',


### PR DESCRIPTION
## Summary
- replace the outdated professional map HTML entry in the service worker cache with the actual app shell
- add index.html and the enhanced popup script so they are available offline alongside the remote Leaflet and Chart.js assets already in use

## Testing
- npm run lint *(warnings only from pre-existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cea91eaf00832d9d89eb9cf3d9d12c