### PR TITLE
Maintain full police event dataset for flexible slicing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2262,6 +2262,7 @@
       constructor() {
         this.state = {
           events: [],
+          allEvents: [],
           filteredEvents: [],
           stations: [],
           currentView: 'markers', // 'markers' | 'heatmap'
@@ -2544,12 +2545,18 @@
           // Try to load cached events first
           const cachedEvents = await DataStorage.getRecentEvents();
 
+          let rehydratedCachedEvents = [];
+
           if (cachedEvents.length > 0) {
             // Recreate event objects from cached data
-            this.state.events = cachedEvents.map(data => {
+            rehydratedCachedEvents = cachedEvents.map(data => {
               const event = Object.create(PoliceEvent.prototype);
               return Object.assign(event, data);
             });
+
+            this.state.events = rehydratedCachedEvents;
+
+            this.state.allEvents = [...this.state.events];
 
             // Immediately show cached events on map
             this.applyFilters();
@@ -2570,22 +2577,22 @@
           const events = rawEvents
             .map(raw => new PoliceEvent(raw))
             .filter(event => event.isValidEvent())
-            .sort((a, b) => b.timeMs - a.timeMs)
-            .slice(0, this.state.maxEvents);
+            .sort((a, b) => b.timeMs - a.timeMs);
 
           // Merge with cached events and deduplicate
           const eventMap = new Map();
 
           // Add cached events first
-          cachedEvents.forEach(event => eventMap.set(event.id, event));
+          rehydratedCachedEvents.forEach(event => eventMap.set(event.id, event));
 
           // Add fresh events (will overwrite cached events with same ID)
           events.forEach(event => eventMap.set(event.id, event));
 
           // Convert back to array and sort
-          this.state.events = Array.from(eventMap.values())
-            .sort((a, b) => b.timeMs - a.timeMs)
-            .slice(0, this.state.maxEvents);
+          this.state.allEvents = Array.from(eventMap.values())
+            .sort((a, b) => b.timeMs - a.timeMs);
+
+          this.state.events = this.state.allEvents.slice(0, this.state.maxEvents);
 
           // Cache new events
           await DataStorage.saveEvents(events);
@@ -2763,8 +2770,8 @@
         input.value = value;
         this.state.maxEvents = value;
 
-        // Re-slice events to new limit
-        this.state.events = this.state.events.slice(0, value);
+        // Re-slice events from full dataset
+        this.state.events = this.state.allEvents.slice(0, value);
         this.applyFilters();
       }
 


### PR DESCRIPTION
## Summary
- add an `allEvents` collection to the application state to keep the complete set of police events available
- hydrate cached events into `allEvents`, merge with freshly fetched data, and slice from the full list when updating the displayed events
- adjust the max event update path to reslice from `allEvents` before reapplying filters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cea930a858832d882730a86393f769